### PR TITLE
Enable wrapping for log output

### DIFF
--- a/lite_series_upgrade.py
+++ b/lite_series_upgrade.py
@@ -833,6 +833,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self.textview = Gtk.TextView(buffer=self.buffer)
         self.textview.set_editable(False)
         self.textview.set_monospace(True)
+        self.textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         scroller.set_child(self.textview)
 
         btn_box = Gtk.Box(spacing=8)


### PR DESCRIPTION
## Summary
- enable word wrapping in the log text view so content flows vertically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c950e2c2388332b27a4648b5c802a5