### PR TITLE
Ensure log output wraps vertically

### DIFF
--- a/lite-series6-upgrade.py
+++ b/lite-series6-upgrade.py
@@ -869,12 +869,14 @@ class MainWindow(Gtk.ApplicationWindow):
 
         scroller = Gtk.ScrolledWindow()
         scroller.set_vexpand(True)
+        scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         outer.append(scroller)
 
         self.buffer = Gtk.TextBuffer()
         self.textview = Gtk.TextView(buffer=self.buffer)
         self.textview.set_editable(False)
         self.textview.set_monospace(True)
+        self.textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         scroller.set_child(self.textview)
 
         btn_box = Gtk.Box(spacing=8)


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling in the log view by disabling the horizontal scrollbar
- wrap log text so entries expand vertically within the view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c951a212148332a0a5344a9cf09081