### PR TITLE
Avoid creating apt sources backups

### DIFF
--- a/lite-series6-upgrade.py
+++ b/lite-series6-upgrade.py
@@ -26,6 +26,8 @@ import tarfile
 import urllib.request
 from pathlib import Path
 
+from lite_series_upgrade.apt_sources import should_backup_apt_source
+
 # GTK
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib, Gio
@@ -597,10 +599,14 @@ class UpgradeEngine:
                 if self.dry_run:
                     self.emit(f"[DRY RUN] Would modify {path}")
                     return True
-                backup = path.with_suffix(path.suffix + f".bak-{int(time.time())}")
-                shutil.copy2(path, backup)
+                if should_backup_apt_source(path):
+                    backup = path.with_suffix(path.suffix + f".bak-{int(time.time())}")
+                    shutil.copy2(path, backup)
+                    message = f"Updated {path} (backup: {backup.name})"
+                else:
+                    message = f"Updated {path} (no backup per policy)"
                 path.write_text(new_content)
-                self.emit(f"Updated {path} (backup: {backup.name})")
+                self.emit(message)
                 return True
             else:
                 self.emit(f"No changes needed in {path}")

--- a/lite_series_upgrade.py
+++ b/lite_series_upgrade.py
@@ -37,6 +37,8 @@ from pathlib import Path
 
 import gi
 
+from lite_series_upgrade.apt_sources import should_backup_apt_source
+
 
 # GTK
 gi.require_version("Gtk", "4.0")
@@ -561,10 +563,14 @@ Prompt=lts
                 if self.dry_run:
                     self.emit(f"[DRY RUN] Would modify {path}")
                     return True
-                backup = path.with_suffix(path.suffix + f".bak-{int(time.time())}")
-                shutil.copy2(path, backup)
+                if should_backup_apt_source(path):
+                    backup = path.with_suffix(path.suffix + f".bak-{int(time.time())}")
+                    shutil.copy2(path, backup)
+                    message = f"Updated {path} (backup: {backup.name})"
+                else:
+                    message = f"Updated {path} (no backup per policy)"
                 path.write_text(new_content)
-                self.emit(f"Updated {path} (backup: {backup.name})")
+                self.emit(message)
                 return True
             self.emit(f"No changes needed in {path}")
             return False

--- a/lite_series_upgrade/apt_sources.py
+++ b/lite_series_upgrade/apt_sources.py
@@ -1,0 +1,54 @@
+"""Helpers for dealing with apt sources files.
+
+The upgrade utility needs to rewrite entries in ``/etc/apt/sources.list`` and
+the accompanying ``sources.list.d`` snippets when switching the release
+codename.  Historically this created timestamped ``.bak`` files which clutter
+the directory and occasionally confused downstream tooling.  The new policy is
+to avoid creating backups for those particular files while keeping the safety
+net for every other path the upgrade touches.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+APT_DIR = Path("/etc/apt")
+APT_SOURCES_LIST = APT_DIR / "sources.list"
+APT_SOURCES_LIST_D = APT_DIR / "sources.list.d"
+
+
+def _normalise(path: Path) -> Path:
+    """Return an absolute variant of *path* without requiring it to exist."""
+
+    try:
+        return path.resolve(strict=False)
+    except Exception:  # pragma: no cover - extremely defensive
+        return path
+
+
+def should_backup_apt_source(path: Path) -> bool:
+    """Return ``False`` when a path refers to an apt sources list entry.
+
+    Only the canonical ``/etc/apt/sources.list`` file and the files located in
+    ``/etc/apt/sources.list.d`` are covered.  Everything else should still be
+    backed up before modifications.
+    """
+
+    normalised = _normalise(path)
+    if normalised == APT_SOURCES_LIST:
+        return False
+
+    try:
+        if normalised.is_relative_to(APT_SOURCES_LIST_D):  # type: ignore[attr-defined]
+            return False
+    except AttributeError:  # pragma: no cover - Python < 3.9 fallback
+        dir_str = str(APT_SOURCES_LIST_D)
+        path_str = str(normalised)
+        if path_str == dir_str or path_str.startswith(dir_str + os.sep):
+            return False
+
+    return True
+
+
+__all__ = ["should_backup_apt_source"]

--- a/tests/test_apt_sources.py
+++ b/tests/test_apt_sources.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from lite_series_upgrade.apt_sources import should_backup_apt_source
+
+
+class TestShouldBackupAptSource:
+    def test_skips_main_sources_list(self) -> None:
+        assert not should_backup_apt_source(Path("/etc/apt/sources.list"))
+
+    def test_skips_sources_list_d_entries(self) -> None:
+        assert not should_backup_apt_source(
+            Path("/etc/apt/sources.list.d/linuxlite.list")
+        )
+
+    def test_other_paths_are_backed_up(self, tmp_path) -> None:
+        other = tmp_path / "sources.list"
+        assert should_backup_apt_source(other)


### PR DESCRIPTION
## Summary
- add an apt sources helper that recognises files under /etc/apt/sources.list*
- update both upgrade entrypoints to skip timestamped backups for those paths while logging the policy
- cover the new helper with tests to ensure only non-apt files still create backups

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c964d09f4c8332bab5149532c52ff9