### PR TITLE
Ensure installed upgrade script locates bundled package

### DIFF
--- a/lite-series6-upgrade.py
+++ b/lite-series6-upgrade.py
@@ -26,7 +26,63 @@ import tarfile
 import urllib.request
 from pathlib import Path
 
-from lite_series_upgrade.apt_sources import should_backup_apt_source
+
+def _add_project_root_to_sys_path() -> bool:
+    """Ensure the bundled ``lite_series_upgrade`` package can be imported."""
+
+    script_path = Path(__file__).resolve()
+    search_roots = [script_path.parent]
+
+    # Walk a couple of parent directories to cover common installation layouts
+    # such as ``/usr/lib/lite-series-upgrade`` with a symlink in ``/usr/bin``.
+    for parent in list(script_path.parents)[:4]:
+        search_roots.append(parent)
+
+    search_roots.extend(
+        Path(path)
+        for path in os.environ.get("LITE_SERIES_UPGRADE_PATH", "").split(os.pathsep)
+        if path
+    )
+
+    search_roots.extend(
+        [
+            Path("/usr/lib/lite-series-upgrade"),
+            Path("/usr/share/lite-series-upgrade"),
+        ]
+    )
+
+    seen: set[Path] = set()
+    for root in search_roots:
+        try:
+            resolved = root.resolve()
+        except FileNotFoundError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+
+        package_init = resolved / "lite_series_upgrade" / "__init__.py"
+        if package_init.exists():
+            root_str = str(resolved)
+            if root_str not in sys.path:
+                sys.path.insert(0, root_str)
+            return True
+
+    return False
+
+
+try:
+    from lite_series_upgrade.apt_sources import should_backup_apt_source
+except ModuleNotFoundError as exc:
+    if exc.name not in {"lite_series_upgrade", "lite_series_upgrade.apt_sources"}:
+        raise
+    if not _add_project_root_to_sys_path():
+        raise ModuleNotFoundError(
+            "lite_series_upgrade package could not be located. Set the"
+            " LITE_SERIES_UPGRADE_PATH environment variable or install the"
+            " project so that the package is available on PYTHONPATH."
+        ) from exc
+    from lite_series_upgrade.apt_sources import should_backup_apt_source
 
 # GTK
 gi.require_version("Gtk", "4.0")


### PR DESCRIPTION
## Summary
- add a helper to locate the bundled `lite_series_upgrade` package when the script is launched from installed locations such as `/usr/bin`
- extend the search to cover common system directories and an override environment variable, raising a clearer error if the package is still missing
- mirror the import bootstrap logic in both script variants to avoid the `ModuleNotFoundError`

## Testing
- pytest
- python3 -m py_compile lite-series6-upgrade.py lite_series_upgrade.py


------
https://chatgpt.com/codex/tasks/task_e_68ca09687ff083328643857dc73a1585