### PR TITLE
Add setup packaging for lite-series upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.py[cod]
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ sudo apt install python3-gi gir1.2-gtk-4.0 \
 > (or symlinked accordingly) and executed via `pkexec` so that it runs with
 > administrative privileges.
 
+## Installation
+
+Install both the launcher script and the accompanying
+`lite_series_upgrade` Python package so the GTK application can import its
+helpers at runtime. The bundled packaging configuration handles this when
+invoked with `pip`:
+
+```bash
+sudo python3 -m pip install .
+```
+
+This places the launcher at `/usr/bin/lite-series6-upgrade.py` and copies the
+`lite_series_upgrade/` directory into `/usr/lib/lite-series-upgrade/`, aligning
+with the import search paths baked into the script. If you prefer manual
+installation, ensure both of those locations exist—copy the launcher into
+`/usr/bin/` and the package directory into `/usr/lib/lite-series-upgrade/`.
+
 ## Usage
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from setuptools import find_packages, setup
+
+ROOT = Path(__file__).parent.resolve()
+PACKAGE_NAME = "lite_series_upgrade"
+PACKAGE_DIR = ROOT / PACKAGE_NAME
+
+PACKAGE_FILES = [
+    str(path.relative_to(ROOT))
+    for path in PACKAGE_DIR.rglob("*")
+    if path.is_file() and path.suffix == ".py"
+]
+
+setup(
+    name="lite-series-upgrade",
+    version="0.1.0",
+    description="GTK4-based desktop utility for upgrading Linux Lite 6.x systems to the 7.x series.",
+    long_description=(ROOT / "README.md").read_text(encoding="utf-8"),
+    long_description_content_type="text/markdown",
+    license="GPL-2.0-only",
+    license_files=["LICENSE"],
+    python_requires=">=3.10",
+    packages=find_packages(where="."),
+    include_package_data=True,
+    zip_safe=False,
+    scripts=["lite-series6-upgrade.py"],
+    data_files=[
+        (f"lib/lite-series-upgrade/{PACKAGE_NAME}", PACKAGE_FILES),
+    ],
+)


### PR DESCRIPTION
## Summary
- add a setuptools-based `setup.py` so installation also installs the launcher and stages the `lite_series_upgrade` package under `/usr/lib/lite-series-upgrade`
- document the need to install both the launcher and package, recommending `pip install .` for convenience
- ignore generated `*.egg-info/` metadata directories

## Testing
- pytest
- python3 setup.py install --root /tmp/pkgroot --prefix=/usr --force

------
https://chatgpt.com/codex/tasks/task_e_68ca12a4a6788332bddd96d16a1a5aac